### PR TITLE
Fix for breaking change in gocql/gocql#983

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -44,10 +44,7 @@ func (driver *Driver) Initialize(rawurl string) error {
 	}
 	if len(u.Query().Get("consistency")) > 0 {
 		var consistency gocql.Consistency
-		consistency, err = gocql.ParseConsistency(u.Query().Get("consistency"))
-		if err != nil {
-			return err
-		}
+		consistency = gocql.ParseConsistency(u.Query().Get("consistency"))
 
 		cluster.Consistency = consistency
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/fatih/color"
 	_ "gopkg.in/mattes/migrate.v1/driver/bash"
-	_ "github.com/feideconnect/migrate/driver/cassandra"
+	_ "github.com/jaimeperez/migrate/driver/cassandra"
 	_ "gopkg.in/mattes/migrate.v1/driver/crate"
 	_ "gopkg.in/mattes/migrate.v1/driver/mssql"
 	_ "gopkg.in/mattes/migrate.v1/driver/neo4j"

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/fatih/color"
 	_ "gopkg.in/mattes/migrate.v1/driver/bash"
-	_ "github.com/jaimeperez/migrate/driver/cassandra"
+	_ "github.com/feideconnect/migrate/driver/cassandra"
 	_ "gopkg.in/mattes/migrate.v1/driver/crate"
 	_ "gopkg.in/mattes/migrate.v1/driver/mssql"
 	_ "gopkg.in/mattes/migrate.v1/driver/neo4j"


### PR DESCRIPTION
This fixes the following error during dataporten building:

```
ERROR: Service 'dataportenschemas' failed to build: The command '/bin/sh -c go get -u -v github.com/feideconnect/migrate' returned a non-zero code: 2
```

The failure was due to a bc-break in gocql/gocql#983 and fixed in gocql/gocql#1002. Unfortunately, the fix was not backwards-compatible, and requires code changes (the one provided here is one of the alternatives).